### PR TITLE
fixed build.js to make sure tmp[p] exists

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -719,7 +719,7 @@ function buildLambdaDirectory(rootDir, opts, callback) {
 										config.profiles.map((p => {
 											tmp[p] = sdkConfigData[p];
 											// Can't Change aws profile in lambda so remove the profile key
-											delete tmp[p].profile;
+											tmp[p] && delete tmp[p].profile;
 										}))
 										sdkConfigData = tmp;
 										sdkConfigData.default = sdkConfigData.default || sdkConfigData[config.defaultProfile] || sdkConfigData[config.profiles[0]];


### PR DESCRIPTION
this will allow for not having to specify all the environments.