### PR TITLE
Needs description and repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
     "name": "leo-cli",
     "version": "1.0.27",
-    "description": "",
+    "description": "A Nodejs interface to interact with the Leo SDK and AWS",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/LeoPlatform/cli.git"
+    },
     "main": "index.js",
     "directories": {
         "test": "test"


### PR DESCRIPTION
Description came from readme.  It also needs repo - this makes it properly link in npm and also won't complain about not having a repo when users npm install it.