### PR TITLE
2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,16 @@ See [leo-config](https://github.com/LeoPlatform/leo-config) for config details. 
 
 options
 * **-e --env [environment]**        Environment.
-* **-cs --changeset**               Only build Changeset.
+* **--changeset**                   Only build Changeset.
 * **-c**                            Only build cloudformation.
+* **-s**                            Save cloudformation.json to the microservice directory.
+* **-F --force-deploy**             Force-deploy without requiring confirmation of changeset.
 * **-d --deploy [environment]**     Deploy the published cloudformation.
 * **-f all --force all**            Force publish and deploy of all bots, including ones without changes.
-* **--filter idGlobExp**			Filters the lambdas deployed by the given glob expression. default: *
-* **--run awsStackName**			Runs the generated cloudformation.json against the AWS Stack 'awsStackName'.  If the stack doesn't exist, it will be crated
-* **--build**						Builds the cloudformation and lambdas but doesn't publish them to s3
-* **--public**						Makes the s3 publish folder public
+* **--filter idGlobExp**            Filters the lambdas deployed by the given glob expression. default: *
+* **--run awsStackName**            Runs the generated cloudformation.json against the AWS Stack 'awsStackName'.  If the stack doesn't exist, it will be crated
+* **--build**                       Builds the cloudformation and lambdas but doesn't publish them to s3
+* **--public**                      Makes the s3 publish folder public
 
 Version of the build using the microservice or bot package.json file.  If a bot is forced to be built and has the same version number the current timestamp will be appended to he version
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "leo-cli",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "description": "A Nodejs interface to interact with the Leo SDK and AWS",
     "repository": {
         "type": "git",


### PR DESCRIPTION
 * Fixed the undefined in the creating stack changeset log
 * Removed bad -cs flag. Multiple characters need a --.
 * Added -s and -F to the documentation.
 * Added forceDeploy (-F) to deploy a changeset without requiring user input.
 * Stopped the progressInterval dots when asking for user input. Restarting again while executing changeset.