### PR TITLE
update access-control-allow-methods for ANY method

### DIFF
--- a/lib/cloud-formation.js
+++ b/lib/cloud-formation.js
@@ -965,7 +965,7 @@ function createApiEntries(ID, swagger, properties) {
 							"statusCode": "200",
 							"responseParameters": {
 								"method.response.header.Access-Control-Max-Age": "'3000'",
-								"method.response.header.Access-Control-Allow-Methods": "'" + (method == "any" ? "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" : method.toUpperCase()) + ",OPTIONS'",
+								"method.response.header.Access-Control-Allow-Methods": "'" + (method == "x-amazon-apigateway-any-method" ? "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" : method.toUpperCase()) + ",OPTIONS'",
 								"method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
 								"method.response.header.Access-Control-Allow-Origin": "'" + config.cors + "'"
 							}


### PR DESCRIPTION
when method is ANY, we should set the Access-Control-Allow-Methods to "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT", which seems to be what was originally intended.  However since the method variable already got changed on line 882, it'll never be "any" again on line 968.