### PR TITLE
Fix Access-Control-Allow-Methods for cors settings

### DIFF
--- a/lib/cloud-formation.js
+++ b/lib/cloud-formation.js
@@ -965,7 +965,7 @@ function createApiEntries(ID, swagger, properties) {
 							"statusCode": "200",
 							"responseParameters": {
 								"method.response.header.Access-Control-Max-Age": "'3000'",
-								"method.response.header.Access-Control-Allow-Methods": "'" + (method == "any" ? "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" : method.toUpperCase()) + ",OPTIONS'",
+								"method.response.header.Access-Control-Allow-Methods": "'" + (method == "any" || method == "x-amazon-apigateway-any-method" ? "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT" : method.toUpperCase()) + ",OPTIONS'",
 								"method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
 								"method.response.header.Access-Control-Allow-Origin": "'" + config.cors + "'"
 							}


### PR DESCRIPTION
The `method` variable gets changed higher in the code to be "x-amazon-apigateway-any-method" rather than "any" which means the Access-Control-Allow-Methods is returning the wrong value