### PR TITLE
Added custom babelify loader at a per-project level 

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -597,14 +597,26 @@ function buildLambdaDirectory(rootDir, opts, callback) {
 		},
 		debug: true
 	});
+
+	let babelPresets = [
+		[path.resolve(__dirname, "../node_modules/babel-preset-env"), {
+			"targets": {
+				"node": "8"
+			}
+		}]
+	];
+
+	// added to allow usage of upgraded @babel/preset-env transformers to support later versions of Node while
+	// still preserving backwards compatibility of leo-cli's older babel-related packages (6x)
+	try {
+		babelify = require.resolve("babelify", { paths: [rootDir] });
+		babelPresets = []; // blow away set presets otherwise .babelrc presets will not be used
+	} catch(e) {
+		// use the older babelify/transformer
+	}
+
 	b.transform(babelify, {
-		presets: [
-			[path.resolve(__dirname, "../node_modules/babel-preset-env"), {
-				"targets": {
-					"node": "8.10"
-				}
-			}]
-		],
+		presets: babelPresets,
 		sourceMaps: false
 	});
 
@@ -852,7 +864,7 @@ function writeCloudFormation(rootDir, opts, program, config, callback) {
 		if (program.saveCloudFormation && config._meta && config._meta.microserviceDir) {
 			fs.writeFileSync(`${config._meta.microserviceDir}/cloudformation.json`, JSON.stringify(cf, null, 2));
 		}
-		
+
 		fs.writeFileSync(`${opts.buildDir}/cloudformation-${now}.json`, JSON.stringify(cf, null, 2));
 		if (opts.variations && Array.isArray(opts.variations) && opts.variations.length) {
 			opts.variations.map(v => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-cli",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "A Nodejs interface to interact with the Leo SDK and AWS",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This can be used with modern @babel style transformers. This is backwards compatible with existing leo-cli build/deploy process.

