### PR TITLE
fix: version 4.0.0-awsv3 → 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-cli",
-	"version": "4.0.0-awsv3",
+	"version": "4.0.0",
 	"description": "A Nodejs interface to interact with the Leo SDK and AWS",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- Remove `-awsv3` prerelease suffix from package version so it publishes as a clean `4.0.0` release

## Task Reference
- Jira: https://chb.atlassian.net/browse/ES-2949

## Changes Made
- `package.json`: `"version": "4.0.0-awsv3"` → `"version": "4.0.0"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a metadata-only version string change with no runtime or dependency modifications.
> 
> **Overview**
> Removes the `-awsv3` prerelease suffix from `package.json` so the package publishes as a clean **`4.0.0`** release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fa02af7064a4164bd9e49cdba01a22201fb4e4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->